### PR TITLE
Bump numpy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: Install dependencies
           command: |
             make build
-            # pip install --editable git+https://github.com/openfisca/openfisca-country-template.git@BRANCH#egg=OpenFisca-Country-Template  # use a specific branch of OpenFisca-Country-template
+            pip install --editable git+https://github.com/openfisca/country-template.git@bump-numpy#egg=OpenFisca-Country-Template  # use a specific branch of OpenFisca-Country-template
 
       - save_cache:
           key: v1-py3-deps-{{ checksum "setup.py" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: Install dependencies
           command: |
             make build
-            # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH#egg=OpenFisca-Core[web-api]  # use a specific branch of OpenFisca-Core
+            # pip install --editable git+https://github.com/openfisca/openfisca-country-template.git@BRANCH#egg=OpenFisca-Country-Template  # use a specific branch of OpenFisca-Country-template
 
       - save_cache:
           key: v1-py3-deps-{{ checksum "setup.py" }}


### PR DESCRIPTION
Checks extension-template with Core update to v35. 
This update comes with a bump of numpy dependency to 1.18 and thus, might have effects on formula syntaxes.