### PR TITLE
Tar.gz in PyPi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 1.3.10 - [#42](https://github.com/openfisca/extension-template/pull/42)
+
+* Technical change
+* Details:
+  - Add tar.gz to PyPi to be used by conda to build conda package.
+
 ### 1.3.9 - [#37](https://github.com/openfisca/extension-template/pull/37)
 
 * Technical change

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clean:
 	find . -name '*.pyc' -exec rm \{\} \;
 
 deps:
-	pip install --upgrade pip twine wheel
+	pip install --upgrade pip build twine
 
 install: deps
 	@# Install OpenFisca-Extension-Template for development.
@@ -20,7 +20,7 @@ build: clean deps
 	@# Install OpenFisca-Extension-Template for deployment and publishing.
 	@# `make build` allows us to be be sure tests are run against the packaged version
 	@# of OpenFisca-Extension-Template, the same we put in the hands of users and reusers.
-	python setup.py bdist_wheel
+	python -m build
 	find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
 
 check-syntax-errors:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ deps:
 
 install: deps
 	@# Install OpenFisca-Extension-Template for development.
-	@# `make install` installs the editable version of OpenFisca-France.
+	@# `make install` installs the editable version of OpenFisca-Extension-Template.
 	@# This allows contributors to test as they code.
 	pip install --editable .[dev] --upgrade
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ build: clean deps
 	@# `make build` allows us to be be sure tests are run against the packaged version
 	@# of OpenFisca-Extension-Template, the same we put in the hands of users and reusers.
 	python -m build
+	pip uninstall --yes openfisca-extension-template
 	find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
 
 check-syntax-errors:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """This file contains your extension package's metadata and dependencies."""
 
 from pathlib import Path
+
 from setuptools import find_packages, setup
 
 # Read the contents of our README file for PyPi

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,15 @@
 """This file contains your extension package's metadata and dependencies."""
 
+from pathlib import Path
 from setuptools import find_packages, setup
+
+# Read the contents of our README file for PyPi
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()  # pylint: disable=W1514
 
 setup(
     name = "OpenFisca-Extension-Template",
-    version = "1.3.9",
+    version = "1.3.10",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers = [
@@ -18,12 +23,15 @@ setup(
         "Topic :: Scientific/Engineering :: Information Analysis",
         ],
     description = "An OpenFisca extension that adds some variables to an already-existing tax and benefit system",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     keywords = "benefit microsimulation social tax",
     license = "http://www.fsf.org/licensing/licenses/agpl-3.0.html",
+    license_files = ("LICENSE",),
     url = "https://github.com/openfisca/extension-template",
     include_package_data = True,  # Will read MANIFEST.in
     data_files = [
-        ("share/openfisca/openfisca-extension-template", ["CHANGELOG.md", "LICENSE", "README.md"]),
+        ("share/openfisca/openfisca-extension-template", ["CHANGELOG.md", "README.md"]),
         ],
     install_requires = [
         "OpenFisca-Country-Template >= 3.8.0,  < 4",

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        'Programming Language :: Python :: 3.9',
         "Topic :: Scientific/Engineering :: Information Analysis",
         ],
     description = "An OpenFisca extension that adds some variables to an already-existing tax and benefit system",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
-        'Programming Language :: Python :: 3.9',
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering :: Information Analysis",
         ],
     description = "An OpenFisca extension that adds some variables to an already-existing tax and benefit system",


### PR DESCRIPTION
Connected to https://github.com/openfisca/openfisca-core/pull/1105

* Technical improvement. 
* Details:
  - Add tar.gz source archive to PyPi to allow conda to use it (next PR coming)

These changes change non-functional parts of this repository : CI