### PR TITLE
Expire deprecated class Bracket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# 2.0.0 - [#46](https://github.com/openfisca/extension-template/pull/46)
+
+#### Breaking change
+
+* Technical improvement.
+* Details:
+  - Expire deprecated class `Bracket`.
+  - Functionality is now provided by `ParameterScaleBracket`
+
 ### 1.3.10 - [#42](https://github.com/openfisca/extension-template/pull/42)
 
 * Technical change

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (this_directory / "README.md").read_text()  # pylint: disable
 
 setup(
     name = "OpenFisca-Extension-Template",
-    version = "1.3.10",
+    version = "2.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers = [
@@ -36,7 +36,7 @@ setup(
         ("share/openfisca/openfisca-extension-template", ["CHANGELOG.md", "README.md"]),
         ],
     install_requires = [
-        "OpenFisca-Country-Template >= 3.8.0,  < 4",
+        "OpenFisca-Country-Template >= 4.0.0.rc1,  < 5.0.0",
         ],
     extras_require = {
         "dev": [


### PR DESCRIPTION
#### Breaking change

* Technical improvement.
* Details:
  - Expire deprecated class `Bracket`.
  - Functionality is now provided by `ParameterScaleBracket`