### PR TITLE
Upgrade OpenAPI to v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-*.pyc
 *.DS_Store
 *.egg-info
+*.pyc
+.idea
+.python-version
 build
 dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+# 2.0.0.rc1 - [#41](https://github.com/openfisca/extension-template/pull/47)
+
+#### New Features
+
+- Upgrade OpenAPI specification of the API to v3 from Swagger v2.
+- Continuously validate OpenAPI specification.
+
+#### Breaking changes
+
+- Drop support for OpenAPI specification v2 and prior.
+- Users relying on the aforesaid can use [this](https://converter.swagger.io/api/convert?url=OAS2_YAML_OR_JSON_URL) to migrate ([example](https://web.archive.org/web/20221103230822/https://converter.swagger.io/api/convert?url=https://api.demo.openfisca.org/latest/spec)).
+
 ### 1.3.10 - [#42](https://github.com/openfisca/extension-template/pull/42)
 
 * Technical change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 2.0.0.rc1 - [#41](https://github.com/openfisca/extension-template/pull/47)
+# 2.0.0 - [#41](https://github.com/openfisca/extension-template/pull/47)
 
 #### New Features
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (this_directory / "README.md").read_text()  # pylint: disable
 
 setup(
     name = "OpenFisca-Extension-Template",
-    version = "2.0.0.rc1",
+    version = "2.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers = [
@@ -36,7 +36,7 @@ setup(
         ("share/openfisca/openfisca-extension-template", ["CHANGELOG.md", "README.md"]),
         ],
     install_requires = [
-        "OpenFisca-Country-Template >= 4.0.0.rc1,  < 5.0.0",
+        "OpenFisca-Country-Template >= 5.0.0,  < 6.0.0",
         ],
     extras_require = {
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (this_directory / "README.md").read_text()  # pylint: disable
 
 setup(
     name = "OpenFisca-Extension-Template",
-    version = "1.3.10",
+    version = "2.0.0.rc1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers = [
@@ -36,7 +36,7 @@ setup(
         ("share/openfisca/openfisca-extension-template", ["CHANGELOG.md", "README.md"]),
         ],
     install_requires = [
-        "OpenFisca-Country-Template >= 3.8.0,  < 4",
+        "OpenFisca-Country-Template >= 4.0.0.rc1,  < 5.0.0",
         ],
     extras_require = {
         "dev": [


### PR DESCRIPTION
#### New Features

- Upgrade OpenAPI specification of the API to v3 from Swagger v2.
- Continuously validate OpenAPI specification.

#### Breaking changes

- Drop support for OpenAPI specification v2 and prior.
- Users relying on the aforesaid can use [this](https://converter.swagger.io/api/convert?url=OAS2_YAML_OR_JSON_URL) to migrate ([example](https://web.archive.org/web/20221103230822/https://converter.swagger.io/api/convert?url=https://api.demo.openfisca.org/latest/spec)).

![screenshot](https://user-images.githubusercontent.com/329236/199855029-8a7a8d2c-2b7f-402d-a571-833d1e93557d.png)
