### PR TITLE
Use PyPi token for authentication on CI deploy job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -133,8 +133,7 @@ jobs:
     needs: [ check-for-functional-changes ]
     if: needs.check-for-functional-changes.outputs.status == 'success'
     env:
-      PYPI_USERNAME: openfisca-bot
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      PYPI_TOKEN_OPENFISCA_BOT: ${{ secrets.PYPI_TOKEN_OPENFISCA_BOT }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -156,6 +155,6 @@ jobs:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
       - name: Upload a Python package to PyPi
-        run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
+        run: twine upload dist/* --username __token__ --password $PYPI_TOKEN_OPENFISCA_BOT
       - name: Publish a git tag
         run: "${GITHUB_WORKSPACE}/.github/publish-git-tag.sh"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -153,6 +153,6 @@ jobs:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
       - name: Upload a Python package to PyPi
-        run: twine upload dist/* --username __token__ --password ${{ secrets.PYPI_TOKEN }}
+        run: twine upload dist/* --username __token__ --password ${{ secrets.PYPI_TOKEN_OPENFISCA_BOT }}
       - name: Publish a git tag
         run: "${GITHUB_WORKSPACE}/.github/publish-git-tag.sh"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -132,8 +132,6 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [ check-for-functional-changes ]
     if: needs.check-for-functional-changes.outputs.status == 'success'
-    env:
-      PYPI_TOKEN_OPENFISCA_BOT: ${{ secrets.PYPI_TOKEN_OPENFISCA_BOT }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -155,6 +153,6 @@ jobs:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
       - name: Upload a Python package to PyPi
-        run: twine upload dist/* --username __token__ --password $PYPI_TOKEN_OPENFISCA_BOT
+        run: twine upload dist/* --username __token__ --password ${{ secrets.PYPI_TOKEN }}
       - name: Publish a git tag
         run: "${GITHUB_WORKSPACE}/.github/publish-git-tag.sh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### [#55](https://github.com/openfisca/extension-template/pull/55)
+
+* Technical improvement.
+* Details:
+  - Use PyPi token for authentication on CI `deploy` job
+  - Allows for Python package upload since the 2FA enforcement on PyPi
+
 ### 1.3.13 - [#53](https://github.com/openfisca/extension-template/pull/53)
 
 * Minor change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [#55](https://github.com/openfisca/extension-template/pull/55)
+### 1.3.14 - [#55](https://github.com/openfisca/extension-template/pull/55)
 
 * Technical improvement.
 * Details:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (this_directory / "README.md").read_text()  # pylint: disable
 
 setup(
     name = "OpenFisca-Extension-Template",
-    version = "1.3.13",
+    version = "1.3.14",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers = [


### PR DESCRIPTION
Context: [2FA Requirement for PyPI begins 2024-01-01](https://blog.pypi.org/posts/2023-06-01-2fa-enforcement-for-upload/)

* Technical improvement.
* Details:
  - Use PyPi token for authentication on CI `deploy` job
  - Allows for Python package upload since the 2FA enforcement on PyPi

- - - -
This PR comes with:
* on PyPi: a PyPi token linked to this repository added to a PyPi account having access to the OpenFisca Extension-Template project (the token is on the openfisca-bot account; we can find it on the [settings page](https://pypi.org/manage/account/))
* on GitHub: a `PYPI_TOKEN_OPENFISCA_BOT` in [this repository secrets](https://github.com/openfisca/extension-template/settings/secrets/actions)

- - - -

These changes :

- Change non-functional parts of this repository (for instance editing the README)
